### PR TITLE
feat: implement MongoDB integration for report service

### DIFF
--- a/Database/DatabaseSettings.cs
+++ b/Database/DatabaseSettings.cs
@@ -1,0 +1,8 @@
+namespace poupeai_report_service.Database;
+
+internal class DatabaseSettings
+{
+    public string ConnectionString { get; set; } = string.Empty;
+    public string DatabaseName { get; set; } = string.Empty;
+    public string CollectionName { get; set; } = string.Empty;
+}

--- a/Enums/AIModel.cs
+++ b/Enums/AIModel.cs
@@ -1,9 +1,21 @@
+using System.ComponentModel;
 using System.Runtime.Serialization;
+using Microsoft.OpenApi.Attributes;
 
 namespace poupeai_report_service.Enums;
 
-internal enum AIModel
+internal enum AIModel : byte
 {
-    Deepseek,
-    Gemini,
+    [Description("Deepseek AI")]
+    [EnumMember(Value = "deepseek")]
+    [Display("Deepseek AI")]
+    /// <summary>
+    /// Deepseek AI model
+    /// </summary>
+    Deepseek = 1,
+
+    [Description("Gemini AI")]
+    [EnumMember(Value = "gemini")]
+    [Display("Gemini AI")]
+    Gemini = 2,
 }

--- a/Models/OverviewReport.cs
+++ b/Models/OverviewReport.cs
@@ -1,0 +1,25 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace poupeai_report_service.Models;
+
+internal class OverviewReport
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    [BsonElement("id")]
+    public string? ReportId { get; init; } = ObjectId.GenerateNewId().ToString();
+
+    [BsonElement("hash")]
+    public string? Hash { get; set; }
+
+    [BsonElement("user_id")]
+    [BsonRepresentation(BsonType.String)]
+    public Guid UserId { get; init; }
+
+    [BsonElement("created_at")]
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+
+    [BsonElement("updated_at")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Routes/ReportsRoutes.cs
+++ b/Routes/ReportsRoutes.cs
@@ -14,8 +14,7 @@ namespace poupeai_report_service.Routes
         {
             var group = app.MapGroup("/api/v1/reports").WithTags("Reports");
 
-            // TODO: Implement overview report generation logic
-            group.MapGet("/overview", OverviewService.GenerateOverviewReport)
+            group.MapPost("/api/v1/overview", OverviewReportOperation)
                 .WithOpenApi(ReportsDocumentation.GetReportsOverviewOperation());
 
             // TODO: Implement expense report generation logic
@@ -34,5 +33,14 @@ namespace poupeai_report_service.Routes
             group.MapPost("/insights", ([AsParameters] PeriodFilters filters, [FromBody] InsightRequest insight) => "Insights report")
                 .WithOpenApi(ReportsDocumentation.GetReportsInsightsOperation());
         }
+
+        private static async Task<IResult> OverviewReportOperation(
+                    [FromServices] IServiceReport overviewService,
+                    [AsParameters] PeriodFilters filters,
+                    [FromServices] IAIService aiService,
+                    [FromQuery] AIModel model)
+                {
+                    return await overviewService.GenerateReport(filters, aiService, model);
+                }
+        }
     }
-}

--- a/Services/IServiceReport.cs
+++ b/Services/IServiceReport.cs
@@ -1,0 +1,10 @@
+using poupeai_report_service.DTOs.Requests;
+using poupeai_report_service.Enums;
+using poupeai_report_service.Interfaces;
+
+namespace poupeai_report_service.Services;
+
+internal interface IServiceReport
+{
+    Task<IResult> GenerateReport(PeriodFilters filters, IAIService aiService, AIModel model = AIModel.Gemini);
+}

--- a/Services/OverviewService.cs
+++ b/Services/OverviewService.cs
@@ -1,17 +1,32 @@
-
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
 using poupeai_report_service.DTOs.Requests;
 using poupeai_report_service.Enums;
 using poupeai_report_service.Interfaces;
+using poupeai_report_service.Models;
+using Serilog;
 
 namespace poupeai_report_service.Services;
 
-internal static class OverviewService
+internal class OverviewService(IMongoDatabase database) : IServiceReport
 {
-    internal static async Task<string> GenerateOverviewReport([AsParameters] PeriodFilters filters, IAIService aiService, [FromQuery] AIModel model = AIModel.Gemini)
+    private readonly Serilog.ILogger _logger = Log.ForContext("Service", nameof(OverviewService));
+
+    private readonly IMongoCollection<OverviewReport> _reportsCollection = database.GetCollection<OverviewReport>("overviewreports");
+
+    public async Task<IResult> GenerateReport(PeriodFilters filters, IAIService aiService, AIModel model = AIModel.Gemini)
     {
         var prompt = $"Gere um relatório geral de finanças para o período de {filters.StartDate} a {filters.EndDate}";
+        //_logger.Information("Generating overview report with prompt", prompt);
 
-        return await aiService.GenerateReportAsync(prompt, model);
+        var report = new OverviewReport
+        {
+            UserId = new Guid(),
+            Hash = "aslaskhdalskjdlaksdj"
+        };
+        await _reportsCollection.InsertOneAsync(report);
+
+        var result = await aiService.GenerateReportAsync(prompt, model);
+        return Results.Ok(result);
     }
 }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,26 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Database": {
+    "DatabaseName": "poupeai-reports",
+    "CollectionName": "overviewreports"
+  },
+  "Serilog": {
+    "Using":  [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+      { "Name": "Console" },
+      { "Name": "File", "Args": { "path": "Logs/log.txt" } }
+    ],
+    "Enrich": [ "FromLogContext" ],
+    "Destructure": [
+      { "Name": "ToMaximumDepth", "Args": { "maximumDestructuringDepth": 4 } },
+      { "Name": "ToMaximumStringLength", "Args": { "maximumStringLength": 100 } },
+      { "Name": "ToMaximumCollectionCount", "Args": { "maximumCollectionCount": 10 } }
+    ],
+    "Properties": {
+        "Application": "poupeai-report-service"
+    }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,23 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Serilog": {
+    "Using":  [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+      { "Name": "Console" },
+      { "Name": "File", "Args": { "path": "Logs/log.txt" } },
+      { "Name": "GrafanaLoki", "Args": { "uri": "http://localhost:8093" } }
+    ],
+    "Enrich": [ "FromLogContext" ],
+    "Destructure": [
+      { "Name": "ToMaximumDepth", "Args": { "maximumDestructuringDepth": 4 } },
+      { "Name": "ToMaximumStringLength", "Args": { "maximumStringLength": 100 } },
+      { "Name": "ToMaximumCollectionCount", "Args": { "maximumCollectionCount": 10 } }
+    ],
+    "Properties": {
+        "Application": "poupeai-report-service"
+    }
+  }
 }

--- a/playground-1.mongodb.js
+++ b/playground-1.mongodb.js
@@ -1,0 +1,43 @@
+/* global use, db */
+// MongoDB Playground
+// Use Ctrl+Space inside a snippet or a string literal to trigger completions.
+
+const database = 'poupeai-reports';
+const collection = 'overviewreports';
+
+// Create a new database.
+use(database);
+
+// Create a new collection.
+db.createCollection(collection);
+
+// The prototype form to create a collection:
+/* db.createCollection( <name>,
+  {
+    capped: <boolean>,
+    autoIndexId: <boolean>,
+    size: <number>,
+    max: <number>,
+    storageEngine: <document>,
+    validator: <document>,
+    validationLevel: <string>,
+    validationAction: <string>,
+    indexOptionDefaults: <document>,
+    viewOn: <string>,
+    pipeline: <pipeline>,
+    collation: <document>,
+    writeConcern: <document>,
+    timeseries: { // Added in MongoDB 5.0
+      timeField: <string>, // required for time series collections
+      metaField: <string>,
+      granularity: <string>,
+      bucketMaxSpanSeconds: <number>, // Added in MongoDB 6.3
+      bucketRoundingSeconds: <number>, // Added in MongoDB 6.3
+    },
+    expireAfterSeconds: <number>,
+    clusteredIndex: <document>, // Added in MongoDB 5.3
+  }
+)*/
+
+// More information on the `createCollection` command can be found at:
+// https://www.mongodb.com/docs/manual/reference/method/db.createCollection/

--- a/poupeai-report-service.csproj
+++ b/poupeai-report-service.csproj
@@ -22,6 +22,9 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
**O que foi solicitado:**  
Implementar conexão com mongoDB

**O que foi feito:**  
- Adicionada a integração do serviço OverviewService com o MongoDB utilizando injeção de dependência do IMongoDatabase.
- Criado o modelo OverviewReport com atributos compatíveis para serialização no MongoDB.
- Implementado o método para inserir relatórios na coleção `overviewreports`.
- Logger Serilog configurado para integração com Loki/Grafana, permitindo rastreabilidade dos logs dos serviços.
- Exemplo de uso do logger contextualizado com o nome do serviço para facilitar filtros no Grafana.

**Observações:**  
Adicionar a connection string do MongoDB via user-secrets para evitar exposição de dados sensíveis no repositório.  
Exemplo:
```bash
dotnet user-secrets set "Database:ConnectionString" "mongodb+srv://usuario:senha@host/db"
```

closes #6 