### PR TITLE
feat: add dedicated savings estimate endpoint with period comparison

### DIFF
--- a/DTOs/Responses/SavingsEstimateResponse.cs
+++ b/DTOs/Responses/SavingsEstimateResponse.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace poupeai_report_service.DTOs.Responses;
+
+/// <summary>
+/// Resposta simples para cálculo de economia estimada.
+/// </summary>
+internal record SavingsEstimateResponse
+{
+    /// <summary>
+    /// Valor da economia estimada em comparação com o período anterior.
+    /// Valor positivo indica economia, negativo indica aumento de gastos.
+    /// </summary>
+    [JsonPropertyName("estimated_savings")]
+    public double EstimatedSavings { get; init; }
+
+    /// <summary>
+    /// Percentual de economia em relação ao período anterior.
+    /// </summary>
+    [JsonPropertyName("savings_percentage")]
+    public double SavingsPercentage { get; init; }
+
+    /// <summary>
+    /// Mensagem explicativa sobre a economia/gasto.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Período de comparação utilizado (ex: "monthly", "weekly").
+    /// </summary>
+    [JsonPropertyName("comparison_period")]
+    public string ComparisonPeriod { get; init; } = string.Empty;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddSingleton(sp =>
 builder.Services.AddScoped<OverviewService>();
 builder.Services.AddScoped<ExpenseService>();
 builder.Services.AddScoped<IncomeService>();
+builder.Services.AddScoped<SavingsEstimateService>();
 
 builder.Services.AddScoped<CategoryService>();
 builder.Services.AddScoped<InsightService>();
@@ -56,5 +57,6 @@ api_group.MapGet("", () => Results.Ok(new {
 }));
 
 app.MapReportsRoutes();
+app.MapSavingsRoutes();
 
 app.Run();

--- a/Routes/SavingsRoutes.cs
+++ b/Routes/SavingsRoutes.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Mvc;
+using poupeai_report_service.DTOs.Requests;
+using poupeai_report_service.Interfaces;
+using poupeai_report_service.Services;
+using poupeai_report_service.Utils;
+using Serilog;
+
+namespace poupeai_report_service.Routes;
+
+/// <summary>
+/// Rotas para funcionalidades relacionadas a economia e comparação de gastos.
+/// </summary>
+public static class SavingsRoutes
+{
+    public static void MapSavingsRoutes(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/savings").WithTags("Savings");
+
+        group.MapPost("/estimate", SavingsEstimateOperation)
+            .WithOpenApi(operation => new(operation)
+            {
+            Summary = "Calcular economia estimada",
+            Description = "Calcula a economia estimada comparando o período atual com o período anterior com base nas datas das transações. " +
+                     "Suporta comparações mensais, semanais e anuais. " +
+                     "Parâmetros de consulta: model (gemini|deepseek, padrão: gemini), comparisonType (monthly|weekly|yearly, padrão: monthly)"
+            });
+    }
+
+    private static async Task<IResult> SavingsEstimateOperation(
+        [FromBody] TransactionsData transactionsData,
+        [FromServices] SavingsEstimateService savingsService,
+        [FromServices] IAIService aiService,
+        [FromQuery] string model = "gemini",
+        [FromQuery] string comparisonType = "monthly"
+    )
+    {
+        try
+        {
+            if (transactionsData?.Transactions == null || !transactionsData.Transactions.Any())
+            {
+                return Results.BadRequest(new 
+                { 
+                    error = "Transaction data is required",
+                    message = "Please provide a list of transactions with dates from multiple periods for comparison"
+                });
+            }
+
+            var aiModel = Tools.StringToModel(model);
+
+            return await savingsService.CalculateEstimatedSavingsAsync(
+                transactionsData, 
+                aiService, 
+                aiModel, 
+                comparisonType);
+        }
+        catch (ArgumentOutOfRangeException ex) when (ex.ParamName == "model")
+        {
+            Log.Error(ex, "Invalid AI model specified: {Model}", model);
+            return Results.BadRequest(new 
+            { 
+                error = "Invalid AI model", 
+                message = $"Model '{model}' is not supported. Use 'gemini' or 'deepseek'." 
+            });
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error calculating savings estimate");
+            return Results.Problem($"An error occurred while calculating the savings estimate: {ex.Message}");
+        }
+    }
+}

--- a/Services/SavingsEstimateService.cs
+++ b/Services/SavingsEstimateService.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using poupeai_report_service.DTOs.Requests;
+using poupeai_report_service.DTOs.Responses;
+using poupeai_report_service.Enums;
+using poupeai_report_service.Interfaces;
+using Serilog;
+
+namespace poupeai_report_service.Services;
+
+internal class SavingsEstimateService
+{
+    private readonly Serilog.ILogger _logger = Log.ForContext<SavingsEstimateService>();
+
+    /// <summary>
+    /// Calcula a economia estimada baseada nas transações, comparando períodos automaticamente.
+    /// </summary>
+    public async Task<IResult> CalculateEstimatedSavingsAsync(
+        TransactionsData transactionsData,
+        IAIService aiService,
+        AIModel model = AIModel.Gemini,
+        string comparisonType = "monthly")
+    {
+        try
+        {
+            if (transactionsData?.Transactions == null || !transactionsData.Transactions.Any())
+            {
+                return Results.BadRequest("Transaction data is required.");
+            }
+
+            // Separar as transações por período baseado nas datas
+            var (currentPeriodTransactions, previousPeriodTransactions) = SeparateTransactionsByPeriod(
+                transactionsData.Transactions, comparisonType);
+
+            if (!previousPeriodTransactions.Any())
+            {
+                return Results.BadRequest($"Insufficient data for {comparisonType} comparison. Need transactions from at least two periods.");
+            }
+
+            var analysisData = new
+            {
+                comparisonType = comparisonType,
+                currentPeriod = new
+                {
+                    transactions = currentPeriodTransactions,
+                    totalExpenses = currentPeriodTransactions.Where(t => t.Amount < 0).Sum(t => Math.Abs(t.Amount)),
+                    totalIncome = currentPeriodTransactions.Where(t => t.Amount > 0).Sum(t => t.Amount)
+                },
+                previousPeriod = new
+                {
+                    transactions = previousPeriodTransactions,
+                    totalExpenses = previousPeriodTransactions.Where(t => t.Amount < 0).Sum(t => Math.Abs(t.Amount)),
+                    totalIncome = previousPeriodTransactions.Where(t => t.Amount > 0).Sum(t => t.Amount)
+                }
+            };
+
+            var prompt = BuildPrompt(analysisData, comparisonType);
+            var dataJson = JsonSerializer.Serialize(analysisData);
+
+            var result = await aiService.GenerateReportAsync(prompt, GetOutputSchema(), model);
+
+            if (string.IsNullOrEmpty(result))
+            {
+                _logger.Error("AI service returned empty result for savings estimate");
+                return Results.Problem("Failed to calculate savings estimate due to empty AI response.");
+            }
+
+            try
+            {
+                var response = JsonSerializer.Deserialize<SavingsEstimateResponse>(result);
+                if (response == null)
+                {
+                    _logger.Error("Failed to deserialize savings estimate response");
+                    return Results.Problem("Failed to process savings estimate response.");
+                }
+
+                _logger.Information("Savings estimate calculated successfully for {ComparisonType} comparison", comparisonType);
+                return Results.Ok(response);
+            }
+            catch (JsonException ex)
+            {
+                _logger.Error(ex, "Error deserializing savings estimate response: {Response}", result);
+                return Results.Problem("Failed to process savings estimate response.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Error calculating savings estimate");
+            return Results.Problem("An error occurred while calculating the savings estimate.");
+        }
+    }
+
+    private static (List<Transaction> current, List<Transaction> previous) SeparateTransactionsByPeriod(
+        List<Transaction> transactions, string comparisonType)
+    {
+        var sortedTransactions = transactions.OrderByDescending(t => t.Date).ToList();
+        var latestDate = sortedTransactions.First().Date;
+
+        var (currentStart, currentEnd, previousStart, previousEnd) = comparisonType.ToLower() switch
+        {
+            "weekly" => GetWeeklyPeriods(latestDate),
+            "monthly" => GetMonthlyPeriods(latestDate),
+            "yearly" => GetYearlyPeriods(latestDate),
+            _ => GetMonthlyPeriods(latestDate) // default to monthly
+        };
+
+        var currentPeriod = transactions
+            .Where(t => t.Date >= currentStart && t.Date <= currentEnd)
+            .ToList();
+
+        var previousPeriod = transactions
+            .Where(t => t.Date >= previousStart && t.Date <= previousEnd)
+            .ToList();
+
+        return (currentPeriod, previousPeriod);
+    }
+
+    private static (DateTime currentStart, DateTime currentEnd, DateTime previousStart, DateTime previousEnd) GetMonthlyPeriods(DateTime referenceDate)
+    {
+        var currentStart = new DateTime(referenceDate.Year, referenceDate.Month, 1);
+        var currentEnd = currentStart.AddMonths(1).AddDays(-1);
+        
+        var previousStart = currentStart.AddMonths(-1);
+        var previousEnd = currentStart.AddDays(-1);
+
+        return (currentStart, currentEnd, previousStart, previousEnd);
+    }
+
+    private static (DateTime currentStart, DateTime currentEnd, DateTime previousStart, DateTime previousEnd) GetWeeklyPeriods(DateTime referenceDate)
+    {
+        var daysFromMonday = (int)referenceDate.DayOfWeek - (int)DayOfWeek.Monday;
+        if (daysFromMonday < 0) daysFromMonday += 7;
+
+        var currentStart = referenceDate.AddDays(-daysFromMonday).Date;
+        var currentEnd = currentStart.AddDays(6);
+        
+        var previousStart = currentStart.AddDays(-7);
+        var previousEnd = currentStart.AddDays(-1);
+
+        return (currentStart, currentEnd, previousStart, previousEnd);
+    }
+
+    private static (DateTime currentStart, DateTime currentEnd, DateTime previousStart, DateTime previousEnd) GetYearlyPeriods(DateTime referenceDate)
+    {
+        var currentStart = new DateTime(referenceDate.Year, 1, 1);
+        var currentEnd = new DateTime(referenceDate.Year, 12, 31);
+        
+        var previousStart = new DateTime(referenceDate.Year - 1, 1, 1);
+        var previousEnd = new DateTime(referenceDate.Year - 1, 12, 31);
+
+        return (currentStart, currentEnd, previousStart, previousEnd);
+    }
+
+    private static string BuildPrompt(object analysisData, string comparisonType)
+    {
+        var dataJson = JsonSerializer.Serialize(analysisData);
+        
+        return $@"
+            Analise os dados financeiros de dois períodos e calcule uma economia estimada simples.
+            
+            Dados para análise (formato JSON):
+            {dataJson}
+
+            Tipo de comparação: {comparisonType}
+
+            Instruções:
+            1. Compare o total de despesas entre o período atual e o anterior
+            2. Calcule a diferença (economia se positiva, aumento de gastos se negativa)
+            3. Calcule o percentual de mudança
+            4. Forneça uma mensagem clara e objetiva sobre o resultado
+
+            Critérios:
+            - Use apenas despesas (valores negativos) para o cálculo
+            - Ignore receitas neste cálculo
+            - Valor positivo = economia (gastou menos que o período anterior)
+            - Valor negativo = aumento de gastos (gastou mais que o período anterior)
+            - Seja preciso com os cálculos matemáticos
+            - Mensagem deve ser clara, concisa e em português
+
+            Retorne apenas o JSON seguindo o schema de output fornecido.
+        ";
+    }
+
+    private static string GetOutputSchema()
+    {
+        return JsonSerializer.Serialize(new
+        {
+            type = "object",
+            properties = new
+            {
+                estimated_savings = new { type = "number" },
+                savings_percentage = new { type = "number" },
+                message = new { type = "string" },
+                comparison_period = new { type = "string" }
+            },
+            required = new[] { "estimated_savings", "savings_percentage", "message", "comparison_period" }
+        });
+    }
+}


### PR DESCRIPTION
# Implementação de Endpoint para Cálculo de Economia Estimada

##  O que foi solicitado

Criar um endpoint separado para calcular a "economia estimada" do usuário, comparando transações de períodos diferentes (ex: mês atual vs mês anterior), utilizando IA, mas retornando apenas um dado simples ("economia estimada").

## O que foi implementado

### 1. **DTO de Resposta Específico**
- **Arquivo**: `DTOs/Responses/SavingsEstimateResponse.cs`
- Resposta simples com economia estimada, percentual, mensagem e período de comparação
- Propriedades com JsonPropertyName para padronização da API

### 2. **Serviço Dedicado**
- **Arquivo**: `Services/SavingsEstimateService.cs`
- Lógica de separação automática de transações por período (mensal, semanal, anual)
- Integração com IA para análise inteligente dos dados
- Cálculo automático de economia baseado apenas em despesas

### 3. **Rotas Separadas**
- **Arquivo**: `Routes/SavingsRoutes.cs`
- Endpoint isolado: `POST /api/v1/savings/estimate`
- Documentação OpenAPI específica
- Tratamento de erros adequado
- Parâmetros de consulta para modelo de IA e tipo de comparação

### 4. **Integração no Sistema**
- **Arquivo**: `Program.cs`
- Registro do novo serviço no DI container
- Mapeamento das novas rotas separadamente dos relatórios

## Como testar

```bash
POST /api/v1/savings/estimate?model=gemini&comparisonType=monthly