### PR TITLE
feat: implement financial transaction categorization service with AI …

### DIFF
--- a/Src/DTOs/Requests/CategorizationRequest.cs
+++ b/Src/DTOs/Requests/CategorizationRequest.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+
+namespace poupeai_report_service.DTOs.Requests;
+
+/// <summary>
+/// Representa uma categoria disponível para classificação.
+/// </summary>
+internal record AvailableCategory
+{
+    [Description("ID da categoria.")]
+    public string Id { get; set; } = null!;
+
+    [Description("Nome da categoria.")]
+    public string Name { get; set; } = null!;
+
+    [Description("Descrição da categoria.")]
+    public string? Description { get; set; }
+}
+
+/// <summary>
+/// Representa os dados necessários para realizar a categorização de transações.
+/// </summary>
+internal record CategorizationRequest
+{
+    [Description("Lista de transações a serem categorizadas.")]
+    public List<Transaction> Transactions { get; set; } = [];
+
+    [Description("Lista de categorias disponíveis para classificação.")]
+    public List<AvailableCategory> AvailableCategories { get; set; } = [];
+}

--- a/Src/DTOs/Responses/Content/CategorizationResponse.cs
+++ b/Src/DTOs/Responses/Content/CategorizationResponse.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace poupeai_report_service.DTOs.Responses.Content;
+
+/// <summary>
+/// Representa a resposta de categorização de transações.
+/// </summary>
+internal record CategorizationResponse
+{
+    /// <summary>
+    /// Mapeamento de descrição da transação para ID da categoria.
+    /// Chave: Descrição da transação
+    /// Valor: ID da categoria atribuída
+    /// </summary>
+    [JsonPropertyName("categorizations")]
+    public Dictionary<string, string> Categorizations { get; init; } = new();
+}

--- a/Src/Schemas/CategorizationOutputSchema.json
+++ b/Src/Schemas/CategorizationOutputSchema.json
@@ -1,0 +1,37 @@
+{
+    "type": "object",
+    "properties": {
+        "header": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "status"
+            ]
+        },
+        "content": {
+            "type": "object",
+            "properties": {
+                "categorizations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Mapeamento de descrição da transação para ID da categoria"
+                }
+            },
+            "required": [
+                "categorizations"
+            ]
+        }
+    },
+    "required": [
+        "header"
+    ]
+}

--- a/Src/Services/Internal/CategorizationService.cs
+++ b/Src/Services/Internal/CategorizationService.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using poupeai_report_service.DTOs.Requests;
+using poupeai_report_service.DTOs.Responses;
+using poupeai_report_service.DTOs.Responses.Content;
+using poupeai_report_service.Enums;
+using poupeai_report_service.Interfaces;
+using poupeai_report_service.Utils;
+using Serilog;
+
+namespace poupeai_report_service.Services.Internal;
+
+/// <summary>
+/// Serviço responsável por categorizar transações usando IA.
+/// Este serviço não persiste dados no banco, apenas retorna o mapeamento de categorizações.
+/// </summary>
+internal class CategorizationService
+{
+    private readonly Serilog.ILogger _logger = Log.ForContext<CategorizationService>();
+    private readonly string _outputSchema;
+
+    public CategorizationService()
+    {
+        _outputSchema = Tools.ReadSchema("CategorizationOutputSchema");
+    }
+
+    /// <summary>
+    /// Categoriza uma lista de transações com base nas categorias disponíveis.
+    /// </summary>
+    /// <param name="request">Dados de categorização contendo transações e categorias disponíveis.</param>
+    /// <param name="aiService">Serviço de IA a ser utilizado.</param>
+    /// <param name="model">Modelo de IA a ser utilizado (padrão: Gemini).</param>
+    /// <returns>Resultado HTTP contendo o mapeamento de categorizações.</returns>
+    public async Task<IResult> CategorizeTransactionsAsync(
+        CategorizationRequest request,
+        IAIService aiService,
+        AIModel model = AIModel.Gemini
+    )
+    {
+        try
+        {
+            if (request.Transactions == null || request.Transactions.Count == 0)
+            {
+                _logger.Warning("No transactions provided for categorization.");
+                return Results.BadRequest(new
+                {
+                    Header = new
+                    {
+                        Status = 400,
+                        Message = "Nenhuma transação fornecida para categorização."
+                    }
+                });
+            }
+
+            if (request.AvailableCategories == null || request.AvailableCategories.Count == 0)
+            {
+                _logger.Warning("No categories provided for categorization.");
+                return Results.BadRequest(new
+                {
+                    Header = new
+                    {
+                        Status = 400,
+                        Message = "Nenhuma categoria disponível para categorização."
+                    }
+                });
+            }
+
+            var dataJson = JsonSerializer.Serialize(new
+            {
+                transactions = request.Transactions.Select(t => new
+                {
+                    description = t.Description,
+                    amount = t.Amount,
+                    type = t.Type
+                }),
+                available_categories = request.AvailableCategories.Select(c => new
+                {
+                    id = c.Id,
+                    name = c.Name,
+                    description = c.Description
+                })
+            });
+
+            var prompt = BuildPrompt(dataJson);
+
+            _logger.Information("Generating categorization using {Model} model for {TransactionCount} transactions and {CategoryCount} categories",
+                Tools.ModelToString(model), request.Transactions.Count, request.AvailableCategories.Count);
+
+            var result = await aiService.GenerateReportAsync(prompt, _outputSchema, model);
+
+            if (string.IsNullOrEmpty(result))
+            {
+                _logger.Error("AI service returned an empty result for categorization.");
+                return Results.Problem("Falha ao categorizar as transações devido a resposta vazia do serviço de IA.");
+            }
+
+            AIResponse<CategorizationResponse>? response;
+            try
+            {
+                response = Tools.DeserializeJson<CategorizationResponse>(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to deserialize AI service response. Raw response: {RawResponse}", result);
+                return Results.Problem("Falha ao categorizar as transações devido a erro de desserialização.");
+            }
+
+            if (response == null)
+            {
+                _logger.Error("Failed to deserialize AI service response. Response was null.");
+                return Results.Problem("Falha ao categorizar as transações devido a erro de desserialização.");
+            }
+
+            if (response.Header.Status != 200)
+            {
+                _logger.Error("AI service returned an error: {Status} - {Message}",
+                    response.Header.Status, response.Header.Message);
+                return Tools.BuildResultFromHeader(response.Header, response.Header.Status);
+            }
+
+            if (response.Content == null || response.Content.Categorizations == null)
+            {
+                _logger.Error("AI service response content is null.");
+                return Results.Problem("Falha ao categorizar as transações devido a conteúdo nulo na resposta da IA.");
+            }
+
+            _logger.Information("Categorization completed successfully with {Count} categorizations",
+                response.Content.Categorizations.Count);
+
+            return Results.Ok(new
+            {
+                response.Header,
+                Content = response.Content
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Error categorizing transactions");
+            return Results.Problem($"Ocorreu um erro ao categorizar as transações: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Constrói o prompt para a IA realizar a categorização.
+    /// </summary>
+    /// <param name="dataJson">JSON contendo as transações e categorias disponíveis.</param>
+    /// <returns>Prompt formatado para a IA.</returns>
+    private string BuildPrompt(string dataJson)
+    {
+        return $@"
+            Você é um assistente de IA especializado em classificação financeira.
+            
+            Sua tarefa é categorizar cada transação fornecida escolhendo ESTRITAMENTE uma das categorias disponíveis.
+            
+            Dados fornecidos (em formato JSON):
+            {dataJson}
+            
+            INSTRUÇÕES IMPORTANTES:
+            1. Para cada transação, analise a descrição, o valor e o tipo (Receita/Despesa).
+            2. Escolha a categoria mais apropriada da lista de categorias disponíveis (available_categories).
+            3. Você DEVE escolher apenas categorias que estão na lista fornecida - NUNCA invente ou crie novas categorias.
+            4. Retorne um JSON mapeando a descrição de cada transação para o ID da categoria escolhida.
+            5. O formato deve ser: {{ ""descricao_transacao"": ""id_categoria"" }}
+            6. Se uma descrição não se encaixar perfeitamente em nenhuma categoria, escolha a mais próxima ou genérica.
+            7. TODAS as transações fornecidas devem ter uma categoria atribuída.
+            
+            Exemplo de resposta esperada:
+            {{
+              ""categorizations"": {{
+                ""Compra no mercado"": ""cat-123"",
+                ""Salário mensal"": ""cat-456"",
+                ""Conta de luz"": ""cat-789""
+              }}
+            }}
+            ";
+    }
+}

--- a/Tests/Services/Internal/CategorizationServiceTests.cs
+++ b/Tests/Services/Internal/CategorizationServiceTests.cs
@@ -1,0 +1,713 @@
+using FluentAssertions;
+using Moq;
+using poupeai_report_service.DTOs.Requests;
+using poupeai_report_service.DTOs.Responses;
+using poupeai_report_service.DTOs.Responses.Content;
+using poupeai_report_service.Enums;
+using poupeai_report_service.Interfaces;
+using poupeai_report_service.Services.Internal;
+using System.Text.Json;
+
+namespace poupeai_report_service.Tests.Services.Internal;
+
+/// <summary>
+/// Testes unitários para o CategorizationService
+/// Caso de Teste: RS-UT-009
+/// </summary>
+public class CategorizationServiceTests
+{
+    private readonly Mock<IAIService> _mockAIService;
+    private readonly CategorizationService _categorizationService;
+
+    public CategorizationServiceTests()
+    {
+        _mockAIService = new Mock<IAIService>();
+        _categorizationService = new CategorizationService();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithValidRequest_ShouldReturnSuccessResult()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                },
+                new()
+                {
+                    Id = 2,
+                    Description = "Salário mensal",
+                    Amount = 5000m,
+                    Type = "Receita",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" },
+                new() { Id = "cat-2", Name = "Salário", Description = "Receitas de trabalho" }
+            }
+        };
+
+        var aiResponse = new AIResponse<CategorizationResponse>
+        {
+            Header = new Header { Status = 200, Message = "Sucesso" },
+            Content = new CategorizationResponse
+            {
+                Categorizations = new Dictionary<string, string>
+                {
+                    { "Compra no supermercado", "cat-1" },
+                    { "Salário mensal", "cat-2" }
+                }
+            }
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ReturnsAsync(JsonSerializer.Serialize(aiResponse));
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // Verificar usando reflexão que é um OK
+        var resultType = result.GetType();
+        resultType.Name.Should().Contain("Ok");
+
+        // Obter o valor
+        var valueProp = resultType.GetProperty("Value");
+        valueProp.Should().NotBeNull();
+
+        var resultValue = valueProp!.GetValue(result);
+        resultValue.Should().NotBeNull();
+
+        var headerProp = resultValue!.GetType().GetProperty("Header");
+        var contentProp = resultValue.GetType().GetProperty("Content");
+
+        headerProp.Should().NotBeNull();
+        contentProp.Should().NotBeNull();
+
+        var header = headerProp!.GetValue(resultValue) as Header;
+        var content = contentProp!.GetValue(resultValue) as CategorizationResponse;
+
+        header.Should().NotBeNull();
+        header!.Status.Should().Be(200);
+
+        content.Should().NotBeNull();
+        content!.Categorizations.Should().HaveCount(2);
+        content.Categorizations.Should().ContainKey("Compra no supermercado");
+        content.Categorizations.Should().ContainKey("Salário mensal");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithEmptyTransactions_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>(),
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // Verificar usando reflexão que é um BadRequest
+        var resultType = result.GetType();
+        resultType.Name.Should().Contain("BadRequest");
+
+        // Tentar obter o valor
+        var valueProp = resultType.GetProperty("Value");
+        if (valueProp != null)
+        {
+            var resultValue = valueProp.GetValue(result);
+            resultValue.Should().NotBeNull();
+
+            var headerProp = resultValue!.GetType().GetProperty("Header");
+            if (headerProp != null)
+            {
+                var header = headerProp.GetValue(resultValue);
+                var statusProp = header!.GetType().GetProperty("Status");
+                var messageProp = header.GetType().GetProperty("Message");
+
+                var status = (int)statusProp!.GetValue(header)!;
+                var message = messageProp!.GetValue(header) as string;
+
+                status.Should().Be(400);
+                message.Should().Contain("transação");
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithNullTransactions_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = null!,
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // Verificar usando reflexão que é um BadRequest
+        var resultType = result.GetType();
+        resultType.Name.Should().Contain("BadRequest");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithEmptyCategories_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>()
+        };
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // Verificar usando reflexão que é um BadRequest
+        var resultType = result.GetType();
+        resultType.Name.Should().Contain("BadRequest");
+
+        // Tentar obter o valor
+        var valueProp = resultType.GetProperty("Value");
+        if (valueProp != null)
+        {
+            var resultValue = valueProp.GetValue(result);
+            resultValue.Should().NotBeNull();
+
+            var headerProp = resultValue!.GetType().GetProperty("Header");
+            if (headerProp != null)
+            {
+                var header = headerProp.GetValue(resultValue);
+                var messageProp = header!.GetType().GetProperty("Message");
+                var message = messageProp!.GetValue(header) as string;
+                message.Should().Contain("categoria");
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithNullCategories_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = null!
+        };
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // Verificar usando reflexão que é um BadRequest
+        var resultType = result.GetType();
+        resultType.Name.Should().Contain("BadRequest");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithEmptyAIResponse_ShouldReturnProblem()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ReturnsAsync(string.Empty);
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        var problemResult = result as Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Should().Contain("vazia");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithInvalidJSON_ShouldReturnProblem()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ReturnsAsync("{ json inválido }");
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        var problemResult = result as Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Should().Contain("desserialização");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithNon200Status_ShouldReturnAppropriateError()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        var aiResponse = new AIResponse<CategorizationResponse>
+        {
+            Header = new Header { Status = 400, Message = "Dados insuficientes" },
+            Content = null
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ReturnsAsync(JsonSerializer.Serialize(aiResponse));
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        // Verificar que não é um resultado OK
+        var resultType = result.GetType();
+        resultType.Name.Should().NotContain("Ok");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithNullContent_ShouldReturnProblem()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        var aiResponse = new AIResponse<CategorizationResponse>
+        {
+            Header = new Header { Status = 200, Message = "Sucesso" },
+            Content = null
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ReturnsAsync(JsonSerializer.Serialize(aiResponse));
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        var problemResult = result as Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Should().Contain("nulo");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithNullCategorizations_ShouldReturnProblem()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        var aiResponse = new AIResponse<CategorizationResponse>
+        {
+            Header = new Header { Status = 200, Message = "Sucesso" },
+            Content = new CategorizationResponse
+            {
+                Categorizations = null!
+            }
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ReturnsAsync(JsonSerializer.Serialize(aiResponse));
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        var problemResult = result as Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Should().Contain("nulo");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithException_ShouldReturnProblem()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .ThrowsAsync(new Exception("Erro de conexão"));
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        var problemResult = result as Microsoft.AspNetCore.Http.HttpResults.ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Should().Contain("erro");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_WithDeepseekModel_ShouldCallAIServiceWithCorrectModel()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra no supermercado",
+                    Amount = -150.50m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        var aiResponse = new AIResponse<CategorizationResponse>
+        {
+            Header = new Header { Status = 200, Message = "Sucesso" },
+            Content = new CategorizationResponse
+            {
+                Categorizations = new Dictionary<string, string>
+                {
+                    { "Compra no supermercado", "cat-1" }
+                }
+            }
+        };
+
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Deepseek))
+            .ReturnsAsync(JsonSerializer.Serialize(aiResponse));
+
+        // Act
+        var result = await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Deepseek
+        );
+
+        // Assert
+        result.Should().NotBeNull();
+        _mockAIService.Verify(
+            x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Deepseek),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public void BuildPrompt_ShouldContainRequiredInstructions()
+    {
+        // Arrange
+        var dataJson = JsonSerializer.Serialize(new
+        {
+            transactions = new[] { new { description = "Test", amount = 100, type = "Despesa" } },
+            available_categories = new[] { new { id = "cat-1", name = "Test", description = "Test" } }
+        });
+
+        // Act
+        var method = typeof(CategorizationService).GetMethod("BuildPrompt",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var prompt = (string)method!.Invoke(_categorizationService, new object[] { dataJson })!;
+
+        // Assert
+        prompt.Should().NotBeNullOrEmpty();
+        prompt.Should().Contain(dataJson);
+        prompt.Should().Contain("ESTRITAMENTE");
+        prompt.Should().Contain("categorizar");
+        prompt.Should().Contain("categoria");
+        prompt.Should().Contain("NUNCA invente");
+        prompt.Should().Contain("descricao_transacao");
+        prompt.Should().Contain("id_categoria");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("TestCase", "RS-UT-009")]
+    public async Task CategorizeTransactionsAsync_ShouldSerializeTransactionsCorrectly()
+    {
+        // Arrange
+        var request = new CategorizationRequest
+        {
+            Transactions = new List<Transaction>
+            {
+                new()
+                {
+                    Id = 1,
+                    Description = "Compra específica",
+                    Amount = -250.75m,
+                    Type = "Despesa",
+                    Date = DateTime.UtcNow
+                }
+            },
+            AvailableCategories = new List<AvailableCategory>
+            {
+                new() { Id = "cat-1", Name = "Alimentação", Description = "Gastos com comida" }
+            }
+        };
+
+        var aiResponse = new AIResponse<CategorizationResponse>
+        {
+            Header = new Header { Status = 200, Message = "Sucesso" },
+            Content = new CategorizationResponse
+            {
+                Categorizations = new Dictionary<string, string>
+                {
+                    { "Compra específica", "cat-1" }
+                }
+            }
+        };
+
+        string? capturedPrompt = null;
+        _mockAIService
+            .Setup(x => x.GenerateReportAsync(It.IsAny<string>(), It.IsAny<string>(), AIModel.Gemini))
+            .Callback<string, string, AIModel>((prompt, schema, model) => capturedPrompt = prompt)
+            .ReturnsAsync(JsonSerializer.Serialize(aiResponse));
+
+        // Act
+        await _categorizationService.CategorizeTransactionsAsync(
+            request,
+            _mockAIService.Object,
+            AIModel.Gemini
+        );
+
+        // Assert
+        capturedPrompt.Should().NotBeNull();
+        capturedPrompt.Should().Contain("Compra espec");
+        capturedPrompt.Should().Contain("-250.75");
+        capturedPrompt.Should().Contain("Despesa");
+        capturedPrompt.Should().Contain("Alimenta");
+    }
+}
+


### PR DESCRIPTION
## O que foi solicitado  
Implementar serviço para categorização de transações financeiras utilizando IA, com validação de schema e testes.

## O que foi feito  
- Criado DTO de request e response para categorização
- Implementado serviço interno de categorização com integração à IA
- Adicionado schema JSON para validação do retorno da IA
- Desenvolvidos testes unitários cobrindo cenários de sucesso e erro

## Testes  
[x] Manuais  
[x] Automatizado